### PR TITLE
Bugfix: Added missing statement for guava update

### DIFF
--- a/proguard/proguard-guava.pro
+++ b/proguard/proguard-guava.pro
@@ -32,3 +32,7 @@
 
 # Guava 20.0
 -dontwarn com.google.**
+
+# Guava 23.5
+-dontwarn afu.org.checkerframework.**
+-dontwarn org.checkerframework.** 


### PR DESCRIPTION
There was a statement missing in the Proguard Guava file, which caused the compiler to throw hundreds of warnings and break the build.